### PR TITLE
Upgrade Storage models to >= 0.11

### DIFF
--- a/lib/fog/storage/google_json/models/directories.rb
+++ b/lib/fog/storage/google_json/models/directories.rb
@@ -5,7 +5,7 @@ module Fog
         model Fog::Storage::GoogleJSON::Directory
 
         def all
-          data = service.list_buckets.body["items"] || []
+          data = service.list_buckets.to_h[:items] || []
           load(data)
         end
 
@@ -14,8 +14,8 @@ module Fog
                                                 :marker     => "marker",
                                                 :max_keys   => "max-keys",
                                                 :prefix     => "prefix")
-          data = service.get_bucket(key, options).body
-          new(:key => data["name"])
+          data = service.get_bucket(key, options).to_h
+          new(data)
         rescue Fog::Errors::NotFound
           nil
         end

--- a/lib/fog/storage/google_json/models/directory.rb
+++ b/lib/fog/storage/google_json/models/directory.rb
@@ -2,15 +2,7 @@ module Fog
   module Storage
     class GoogleJSON
       class Directory < Fog::Model
-        identity :key, :aliases => %w(Name name)
-
-        def acl=(new_acl)
-          valid_acls = %w(private projectPrivate publicRead publicReadWrite authenticatedRead)
-          unless valid_acls.include?(new_acl)
-            raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
-          end
-          @acl = new_acl
-        end
+        identity :key, :aliases => ["Name", "name", :name]
 
         def destroy
           requires :key
@@ -29,31 +21,18 @@ module Fog
           end
         end
 
-        def public=(new_public)
-          if new_public
-            @acl = "publicRead"
-          else
-            @acl = "private"
-          end
-          new_public
-        end
-
         def public_url
           requires :key
-          acl = service.get_bucket_acl(key).body
-          if acl["items"].detect { |entry| entry["entity"] == "allUsers" && entry["role"] == "READER" }
-            if key.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
-              "https://#{key}.storage.googleapis.com"
-            else
-              "https://storage.googleapis.com/#{key}"
-            end
+          if key.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
+            "https://#{key}.storage.googleapis.com"
           end
+          "https://storage.googleapis.com/#{key}"
         end
 
         def save
           requires :key
           options = {}
-          options["predefinedAcl"] = @acl if @acl
+          options["predefinedAcl"] = attributes[:predefined_acl] if attributes[:predefined_acl]
           options["LocationConstraint"] = @location if @location
           options["StorageClass"] = attributes[:storage_class] if attributes[:storage_class]
           service.put_bucket(key, options)

--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -2,45 +2,27 @@ module Fog
   module Storage
     class GoogleJSON
       class File < Fog::Model
-        identity :key, :aliases => %w{Key name}
+        identity :key, :aliases => ["Key", :name]
 
         attribute :acl
-        attribute :predefined_acl
-        attribute :cache_control,       :aliases => "cacheControl"
-        attribute :content_disposition, :aliases => "contentDisposition"
-        attribute :content_encoding,    :aliases => "contentEncoding"
-        attribute :content_length,      :aliases => "size", :type => :integer
-        attribute :content_md5,         :aliases => "md5Hash"
-        attribute :content_type,        :aliases => "contentType"
+        attribute :predefined_acl,      :aliases => ["predefinedAcl", :predefined_acl]
+        attribute :cache_control,       :aliases => ["cacheControl", :cache_control]
+        attribute :content_disposition, :aliases => ["contentDisposition", :content_disposition]
+        attribute :content_encoding,    :aliases => ["contentEncoding", :content_encoding]
+        attribute :content_length,      :aliases => ["size", :size], :type => :integer
+        attribute :content_md5,         :aliases => ["md5Hash", :md5_hash]
+        attribute :content_type,        :aliases => ["contentType", :content_type]
         attribute :crc32c
-        attribute :etag,                :aliases => "etag"
-        attribute :time_created,        :aliases => "timeCreated"
-        attribute :last_modified,       :aliases => "updated"
+        attribute :etag,                :aliases => ["etag", :etag]
+        attribute :time_created,        :aliases => ["timeCreated", :time_created]
+        attribute :last_modified,       :aliases => ["updated", :updated]
         attribute :generation
         attribute :metageneration
-        attribute :metadata
-        attribute :self_link,           :aliases => "selfLink"
-        attribute :media_link,          :aliases => "mediaLink"
+        attribute :metadata,            :aliases => ["metadata", :metadata]
+        attribute :self_link,           :aliases => ["selfLink", :self_link]
+        attribute :media_link,          :aliases => ["mediaLink", :media_link]
         attribute :owner
         attribute :storage_class, :aliases => "storageClass"
-
-        @valid_predefined_acls = %w(private projectPrivate bucketOwnerFullControl bucketOwnerRead authenticatedRead publicRead)
-
-        def predefined_acl=(new_acl)
-          unless @valid_predefined_acls.include?(new_acl)
-            raise ArgumentError.new("acl must be one of [#{@valid_predefined_acls.join(', ')}]")
-          end
-          @predefined_acl = new_acl
-        end
-
-        # TODO: Implement object ACLs
-        # def acl=(new_acl)
-        #   valid_acls = ["private", "projectPrivate", "bucketOwnerFullControl", "bucketOwnerRead", "authenticatedRead", "publicRead"]
-        #   unless valid_acls.include?(new_acl)
-        #     raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
-        #   end
-        #   @acl = new_acl
-        # end
 
         def body
           attributes[:body] ||= last_modified && (file = collection.get(identity)) ? file.body : ""
@@ -67,47 +49,12 @@ module Fog
           false
         end
 
-        remove_method :metadata=
-        def metadata=(new_metadata)
-          if attributes[:metadata].nil?
-            attributes[:metadata] = {}
-          end
-          attributes[:metadata].merge!(new_metadata)
-        end
-
-        # TODO: Not functional
-        remove_method :owner=
-        def owner=(new_owner)
-          if new_owner
-            attributes[:owner] = {
-              :entity => new_owner["entity"],
-              :entityId  => new_owner["entityId"]
-            }
-          end
-        end
-
-        def public=(new_public)
-          if new_public
-            @predefined_acl = "publicRead"
-          else
-            @predefined_acl = "private"
-          end
-          new_public
-        end
-
         def public_url
           requires :directory, :key
-
-          acl = service.get_object_acl(directory.key, key).body
-          access_granted = acl["items"].detect { |entry| entry["entity"] == "allUsers" && entry["role"] == "READER" }
-
-          if access_granted
-            if directory.key.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
-              "https://#{directory.key}.storage.googleapis.com/#{key}"
-            else
-              "https://storage.googleapis.com/#{directory.key}/#{key}"
-            end
+          if directory.key.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
+            "https://#{directory.key}.storage.googleapis.com/#{key}"
           end
+          "https://storage.googleapis.com/#{directory.key}/#{key}"
         end
 
         def save(options = {})
@@ -116,18 +63,14 @@ module Fog
             Fog::Logger.deprecation("options param is deprecated, use acl= instead [light_black](#{caller.first})[/]")
           end
           options["contentType"] = content_type if content_type
-          options["predefinedAcl"] ||= @predefined_acl if @predefined_acl # predefinedAcl may need to be in parameters
-          options["acl"] ||= @acl if @acl # Not sure if you can provide both acl and predefinedAcl
+          options["predefinedAcl"] ||= predefined_acl if predefined_acl # predefinedAcl may need to be in parameters
+          options["acl"] ||= acl if acl # Not sure if you can provide both acl and predefinedAcl
           options["cacheControl"] = cache_control if cache_control
           options["contentDisposition"] = content_disposition if content_disposition
           options["contentEncoding"] = content_encoding if content_encoding
-          # TODO: Should these hashes be recomputed on changes to file contents?
-          # options["md5Hash"] = content_md5 if content_md5
-          # options["crc32c"] = crc32c if crc32c
           options["metadata"] = metadata
 
-          data = service.put_object(directory.key, key, body, options)
-          merge_attributes(data.headers.reject { |key, _value| %w(contentLength contentType).include?(key) })
+          service.put_object(directory.key, key, body, options)
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)
           true

--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -20,6 +20,7 @@ module Fog
         def put_object(bucket_name, object_name, data, options = {})
           unless options["Content-Type"]
             if data.is_a? String
+              data = StringIO.new(data)
               options["Content-Type"] = "text/plain"
             elsif data.is_a? ::File
               options["Content-Type"] = Fog::Storage.parse_data(data)[:headers]["Content-Type"]

--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -8,6 +8,7 @@ module Fog
         # @param bucket_name [String] Name of bucket to create object in
         # @param object_name [String] Name of object to create
         # @param data [File|String] File or String to create object from
+        # @option options [String] "predefinedAcl" Applies a predefined set of access controls to this bucket.
         # @option options [String] "Cache-Control" Caching behaviour
         # @option options [DateTime] "Content-Disposition" Presentational information for the object
         # @option options [String] "Content-Encoding" Encoding of object data
@@ -31,6 +32,7 @@ module Fog
           request_options = ::Google::Apis::RequestOptions.default.merge(options)
           @storage_json.insert_object(bucket_name, object_config,
                                       :upload_source => data,
+                                      :predefined_acl => options["predefinedAcl"],
                                       :options => request_options)
         end
       end

--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -19,7 +19,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          params[:path] = CGI.escape(params[:path]).gsub("%2F", "/")
+          params[:path] = URI.encode(params[:path]).gsub("%2F", "/")
           query = [params[:query]].compact
           query << "GoogleAccessId=#{@client.issuer}"
           query << "Signature=#{CGI.escape(signature(params))}"

--- a/test/integration/storage/storage_shared.rb
+++ b/test/integration/storage/storage_shared.rb
@@ -78,7 +78,7 @@ class StorageShared < FogIntegrationTest
   def some_object_name
     # create lazily to speed tests up
     @some_object ||= new_object_name.tap do |t|
-      @client.put_object(some_bucket_name, t, some_temp_file_name)
+      @client.put_object(some_bucket_name, t, some_temp_file)
     end
   end
 
@@ -86,11 +86,11 @@ class StorageShared < FogIntegrationTest
     "hello world"
   end
 
-  def some_temp_file_name
+  def some_temp_file
     @some_temp_file ||= Tempfile.new("fog-google-storage").tap do |t|
       t.write(temp_file_content)
       t.close
     end
-    @some_temp_file.path
+    File.open(@some_temp_file.path, "r")
   end
 end

--- a/test/integration/storage/storage_shared.rb
+++ b/test/integration/storage/storage_shared.rb
@@ -7,9 +7,13 @@ require "tempfile"
 class StorageShared < FogIntegrationTest
   def setup
     @client = Fog::Storage::Google.new
+    # Enable retries during the suite. This prevents us from
+    # having to manually rate limit our requests.
+    ::Google::Apis::RequestOptions.default.retries = 5
     # Ensure any resources we create with test prefixes are removed
     Minitest.after_run do
       delete_test_resources
+      ::Google::Apis::RequestOptions.default.retries = 0
     end
   end
 
@@ -32,7 +36,6 @@ class StorageShared < FogIntegrationTest
             end
 
             begin
-              sleep(2)
               @client.delete_bucket(t)
             # Given that bucket operations are specifically rate-limited, we handle that
             # by waiting a significant amount of time and trying.
@@ -68,7 +71,6 @@ class StorageShared < FogIntegrationTest
   def some_bucket_name
     # create lazily to speed tests up
     @some_bucket ||= new_bucket_name.tap do |t|
-      sleep(1.5)
       @client.put_bucket(t)
     end
   end

--- a/test/integration/storage/storage_shared.rb
+++ b/test/integration/storage/storage_shared.rb
@@ -43,8 +43,6 @@ class StorageShared < FogIntegrationTest
             end
           end
       # We ignore errors here as list operations may not represent changes applied recently.
-      # Hence, list operations can return a topic which has already been deleted but which we
-      # will attempt to delete again.
       rescue Google::Apis::Error
         Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
       end

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -14,6 +14,24 @@ class TestStorageRequests < StorageShared
     assert_equal(bucket.name, bucket_name)
   end
 
+  # We cannot test the state of the ACL as there are two cases to consider
+  # * The authenticated service account has Owner permisions, which allows
+  # it to read the ACLs after the predefined ACL is applied.
+  # * The authenticated service account does not have Owner  permissions,
+  # then, we cannot read the ACLs after the predefined ACL is applied.
+  #
+  # As we cannot control the service account used for testing, we'll
+  # just ensure that a valid operation succeeds and an invalid operation fails.
+  def test_put_bucket_predefined_acl
+    @client.put_bucket(new_bucket_name, "predefinedAcl" => "publicRead")
+  end
+
+  def test_put_bucket_invalid_predefined_acl
+    assert_raises(Google::Apis::ClientError) do
+      @client.put_bucket(new_bucket_name, "predefinedAcl" => "invalidAcl")
+    end
+  end
+
   def test_get_bucket
     sleep(1)
 

--- a/test/integration/storage/test_buckets.rb
+++ b/test/integration/storage/test_buckets.rb
@@ -6,8 +6,6 @@ require "tempfile"
 
 class TestStorageRequests < StorageShared
   def test_put_bucket
-    sleep(1)
-
     bucket_name = new_bucket_name
     bucket = @client.put_bucket(bucket_name)
 
@@ -33,15 +31,11 @@ class TestStorageRequests < StorageShared
   end
 
   def test_get_bucket
-    sleep(1)
-
     bucket = @client.get_bucket(some_bucket_name)
     assert_equal(bucket.name, some_bucket_name)
   end
 
   def test_delete_bucket
-    sleep(1)
-
     # Create a new bucket to delete it
     bucket_to_delete = new_bucket_name
     @client.put_bucket(bucket_to_delete)
@@ -54,8 +48,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_list_buckets
-    sleep(1)
-
     # Create a new bucket to ensure at least one exists to find
     bucket_name = new_bucket_name
     @client.put_bucket(bucket_name)
@@ -70,8 +62,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_put_bucket_acl
-    sleep(1)
-
     bucket_name = new_bucket_name
     @client.put_bucket(bucket_name)
 
@@ -83,8 +73,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_get_bucket_acl
-    sleep(1)
-
     bucket_name = new_bucket_name
     @client.put_bucket(bucket_name)
 

--- a/test/integration/storage/test_directories.rb
+++ b/test/integration/storage/test_directories.rb
@@ -6,8 +6,6 @@ require "tempfile"
 
 class TestStorageRequests < StorageShared
   def test_directories_put
-    sleep(1)
-
     dir_name = new_bucket_name
     directory = @client.directories.create(:key => dir_name)
     assert_equal(directory.key, dir_name)
@@ -30,29 +28,21 @@ class TestStorageRequests < StorageShared
   end
 
   def test_directories_get
-    sleep(1)
-
     directory = @client.directories.get(some_bucket_name)
     assert_equal(directory.key, some_bucket_name)
   end
 
   def test_directory_files
-    sleep(1)
-
     file = @client.directories.get(some_bucket_name).files.get(some_object_name)
     assert_equal(some_object_name, file.key)
   end
 
   def test_directory_public_url
-    sleep(1)
-
     url = @client.directories.get(some_bucket_name).public_url
     assert_match(/storage.googleapis.com/, url)
   end
 
   def test_directories_destroy
-    sleep(1)
-
     dir_name = new_bucket_name
     @client.directories.create(:key => dir_name)
 
@@ -64,7 +54,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_directories_all
-    sleep(1)
     dir_name = new_bucket_name
     @client.directories.create(:key => dir_name)
 

--- a/test/integration/storage/test_directories.rb
+++ b/test/integration/storage/test_directories.rb
@@ -1,60 +1,80 @@
 require "helpers/integration_test_helper"
+require "integration/storage/storage_shared"
+require "securerandom"
+require "base64"
+require "tempfile"
 
-class TestDirectories < FogIntegrationTest
-  begin
-    client_email = Fog.credentials[:google_client_email]
-    @@connection = Fog::Storage::Google.new
-    @@connection.put_bucket("fog-smoke-test", options: { "acl" => [{ :entity => "user-" + client_email, :role => "OWNER" }] })
-    @@connection.put_bucket_acl("fog-smoke-test", :entity => "allUsers", :role => "READER")
-    @@directory = @@connection.directories.get("fog-smoke-test")
-  rescue Exception => e
-    puts e
+class TestStorageRequests < StorageShared
+  def test_directories_put
+    sleep(1)
+
+    dir_name = new_bucket_name
+    directory = @client.directories.create(:key => dir_name)
+    assert_equal(directory.key, dir_name)
   end
 
-  Minitest.after_run do
-    begin
-      @connection = Fog::Storage::Google.new
-      @connection.delete_bucket("fog-smoke-test")
-    rescue Exception => e
-      puts e
+  def test_directories_put_predefined_acl
+    @client.directories.create(
+      :key => new_bucket_name,
+      :predefined_acl => "publicRead"
+    )
+  end
+
+  def test_directories_put_invalid_predefined_acl
+    assert_raises(Google::Apis::ClientError) do
+      @client.directories.create(
+        :key => new_bucket_name,
+        :predefined_acl => "invalidAcl"
+      )
     end
   end
 
-  def setup
-    @connection = @@connection
-    @directory = @@directory
+  def test_directories_get
+    sleep(1)
+
+    directory = @client.directories.get(some_bucket_name)
+    assert_equal(directory.key, some_bucket_name)
   end
 
-  def test_all_directories
-    skip
+  def test_directory_files
+    sleep(1)
+
+    file = @client.directories.get(some_bucket_name).files.get(some_object_name)
+    assert_equal(some_object_name, file.key)
   end
 
-  def test_get_directory
-    directory_get = @connection.directories.get("fog-smoke-test")
-    assert_instance_of Fog::Storage::Google::Directory, directory_get
+  def test_directory_public_url
+    sleep(1)
+
+    url = @client.directories.get(some_bucket_name).public_url
+    assert_match(/storage.googleapis.com/, url)
   end
 
-  def test_create_destroy_directory
-    directory_create = @connection.directories.create(:key => "fog-smoke-test-create-destroy")
-    assert_instance_of Fog::Storage::Google::Directory, directory_create
-    assert directory_create.destroy
+  def test_directories_destroy
+    sleep(1)
+
+    dir_name = new_bucket_name
+    @client.directories.create(:key => dir_name)
+
+    @client.directories.destroy(dir_name)
+
+    assert_raises(Google::Apis::ClientError) do
+      @client.directories.get(dir_name)
+    end
   end
 
-  def test_public_url
-    public_url = @directory.public_url
-    assert_match(/storage\.googleapis\.com/, public_url)
-    assert_match(/fog-smoke-test/, public_url)
-  end
+  def test_directories_all
+    sleep(1)
+    dir_name = new_bucket_name
+    @client.directories.create(:key => dir_name)
 
-  def test_public
-    skip
-  end
+    result = @client.directories.all
+    if result.nil?
+      raise StandardError.new("no directories found")
+    end
 
-  def test_files
-    skip
-  end
-
-  def test_acl
-    skip
+    unless result.any? { |directory| directory.key == dir_name }
+      raise StandardError.new("failed to find expected directory")
+    end
   end
 end

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -6,8 +6,6 @@ require "tempfile"
 
 class TestStorageRequests < StorageShared
   def test_files_create
-    sleep(1)
-
     @client.directories.get(some_bucket_name).files.create(
       :key => new_object_name,
       :body => some_temp_file_name
@@ -34,23 +32,17 @@ class TestStorageRequests < StorageShared
   end
 
   def test_files_get
-    sleep(1)
-
     content = @client.directories.get(some_bucket_name).files.get(some_object_name)
     assert_equal(content.body, temp_file_content)
   end
 
   def test_files_head
-    sleep(1)
-
     content = @client.directories.get(some_bucket_name).files.head(some_object_name)
     assert_equal(content.content_length, temp_file_content.length)
     assert_equal(content.key, some_object_name)
   end
 
   def test_files_destroy
-    sleep(1)
-
     file_name = new_object_name
     @client.directories.get(some_bucket_name).files.create(
       :key => file_name,
@@ -65,8 +57,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_files_all
-    sleep(1)
-
     file_name = new_object_name
     @client.directories.get(some_bucket_name).files.create(
       :key => file_name,
@@ -100,8 +90,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_files_copy
-    sleep(1)
-
     target_object_name = new_object_name
     @client.directories.get(some_bucket_name).files.get(some_object_name).copy(some_bucket_name,
                                                                                target_object_name)
@@ -111,8 +99,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_files_public_url
-    sleep(1)
-
     url = @client.directories.get(some_bucket_name).files.get(some_object_name).public_url
     assert_match(/storage.googleapis.com/, url)
   end

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -125,7 +125,11 @@ class TestStorageRequests < StorageShared
     assert_match(/fog-testfile/, https_url)
   end
 
-  def test_url
-    skip
+  def test_files_get_https_url_whitespace
+    directory = @client.directories.get(some_bucket_name)
+    https_url = directory.files.get_https_url("fog -testfile", (Time.now + 60).to_i)
+    assert_match(/https/, https_url)
+    assert_match(/#{bucket_prefix}/, https_url)
+    assert_match(/fog\%20-testfile/, https_url)
   end
 end

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -5,20 +5,34 @@ require "base64"
 require "tempfile"
 
 class TestStorageRequests < StorageShared
-  def test_put_object
+  def test_put_object_string
     object_name = new_object_name
-    object = @client.put_object(some_bucket_name, object_name, some_temp_file_name)
-    assert_equal(object_name, object.name)
+    @client.put_object(some_bucket_name, object_name, some_temp_file)
+
+    object = @client.get_object(some_bucket_name, object_name)
+
+    assert_equal(object_name, object[:name])
+    assert_equal(temp_file_content, object[:body])
+  end
+
+  def test_put_object_file
+    object_name = new_object_name
+    expected_body = "A file body"
+    @client.put_object(some_bucket_name, object_name, expected_body)
+
+    object = @client.get_object(some_bucket_name, object_name)
+    assert_equal(object_name, object[:name])
+    assert_equal(expected_body, object[:body])
   end
 
   def test_put_object_predefined_acl
-    @client.put_object(some_bucket_name, new_object_name, some_temp_file_name,
+    @client.put_object(some_bucket_name, new_object_name, some_temp_file,
                        "predefinedAcl" => "publicRead")
   end
 
   def test_put_object_invalid_predefined_acl
     assert_raises(Google::Apis::ClientError) do
-      @client.put_object(some_bucket_name, new_object_name, some_temp_file_name,
+      @client.put_object(some_bucket_name, new_object_name, some_temp_file,
                          "predefinedAcl" => "invalidAcl")
     end
   end
@@ -30,7 +44,7 @@ class TestStorageRequests < StorageShared
 
   def test_delete_object
     object_name = new_object_name
-    @client.put_object(some_bucket_name, object_name, some_temp_file_name)
+    @client.put_object(some_bucket_name, object_name, some_temp_file)
     @client.delete_object(some_bucket_name, object_name)
 
     assert_raises(Google::Apis::ClientError) do
@@ -67,7 +81,7 @@ class TestStorageRequests < StorageShared
 
   def test_put_object_acl
     object_name = new_object_name
-    @client.put_object(some_bucket_name, object_name, some_temp_file_name)
+    @client.put_object(some_bucket_name, object_name, some_temp_file)
 
     acl = {
       :entity => "allUsers",
@@ -78,7 +92,7 @@ class TestStorageRequests < StorageShared
 
   def test_get_object_acl
     object_name = new_object_name
-    @client.put_object(some_bucket_name, object_name, some_temp_file_name)
+    @client.put_object(some_bucket_name, object_name, some_temp_file)
 
     acl = {
       :entity => "allUsers",

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -6,8 +6,6 @@ require "tempfile"
 
 class TestStorageRequests < StorageShared
   def test_put_object
-    sleep(1)
-
     object_name = new_object_name
     object = @client.put_object(some_bucket_name, object_name, some_temp_file_name)
     assert_equal(object_name, object.name)
@@ -26,15 +24,11 @@ class TestStorageRequests < StorageShared
   end
 
   def test_get_object
-    sleep(1)
-
     object = @client.get_object(some_bucket_name, some_object_name)
     assert_equal(temp_file_content, object[:body])
   end
 
   def test_delete_object
-    sleep(1)
-
     object_name = new_object_name
     @client.put_object(some_bucket_name, object_name, some_temp_file_name)
     @client.delete_object(some_bucket_name, object_name)
@@ -45,16 +39,12 @@ class TestStorageRequests < StorageShared
   end
 
   def test_head_object
-    sleep(1)
-
     object = @client.head_object(some_bucket_name, some_object_name)
     assert_equal(temp_file_content.length, object.size)
     assert_equal(some_bucket_name, object.bucket)
   end
 
   def test_copy_object
-    sleep(1)
-
     target_object_name = new_object_name
 
     @client.copy_object(some_bucket_name, some_object_name,
@@ -64,8 +54,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_list_objects
-    sleep(1)
-
     expected_object = some_object_name
 
     result = @client.list_objects(some_bucket_name)
@@ -78,8 +66,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_put_object_acl
-    sleep(1)
-
     object_name = new_object_name
     @client.put_object(some_bucket_name, object_name, some_temp_file_name)
 
@@ -91,8 +77,6 @@ class TestStorageRequests < StorageShared
   end
 
   def test_get_object_acl
-    sleep(1)
-
     object_name = new_object_name
     @client.put_object(some_bucket_name, object_name, some_temp_file_name)
 

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -13,6 +13,18 @@ class TestStorageRequests < StorageShared
     assert_equal(object_name, object.name)
   end
 
+  def test_put_object_predefined_acl
+    @client.put_object(some_bucket_name, new_object_name, some_temp_file_name,
+                       "predefinedAcl" => "publicRead")
+  end
+
+  def test_put_object_invalid_predefined_acl
+    assert_raises(Google::Apis::ClientError) do
+      @client.put_object(some_bucket_name, new_object_name, some_temp_file_name,
+                         "predefinedAcl" => "invalidAcl")
+    end
+  end
+
   def test_get_object
     sleep(1)
 


### PR DESCRIPTION
Models have been minimally changed to work against rewritten
requests. Model tests have been added.

This follows up the previous changes to Storage requests
bf540a09c5a70e63d32bc86e0e1c107c6fe8d50f

The ACL operations, which operated mainly using predefined
ACLs, have been removed as they were previously unimplemented.
When I attempted to implement them, I ran into a semantics
mismatch with what we are allowed to use predefined ACLs for.
You can create an object or bucket with a predefined ACL.
You cannot update an object or bucket with a predefined ACL.
I confirmed this behavior is acknowledged internally
and will not be changed.

This was mentioned in google-cloud-ruby
https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/381
(Final paragraph)

To reproduce this ACL issue:
Create a new bucket in GCP console, add an object using upload.
Try to use the 'Objects: patch' method with the API Explorer
to change to a predefined ACL. You will encounter the following error

```
"code": 409,
  "message": "Cannot provide both a predefinedAcl and access controls."
```

https://cloud.google.com/storage/docs/json_api/v1/objects/patch